### PR TITLE
Replace "use vars" with "our"

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -17,7 +17,6 @@ Test::Needs=0
 [Prereqs]
 perl=5.010001
 strict=0
-vars=0
 warnings=0
 Complete::File=0.440
 Complete::Util=0.608

--- a/lib/App/perlmv/scriptlet/remove_common_prefix.pm
+++ b/lib/App/perlmv/scriptlet/remove_common_prefix.pm
@@ -14,7 +14,7 @@ our $SCRIPTLET = {
     code => sub {
         package
             App::perlmv::code;
-        use vars qw($COMMON_PREFIX $TESTING $FILES);
+        our ($COMMON_PREFIX, $TESTING, $FILES);
 
         if (!defined($COMMON_PREFIX) && !$TESTING) {
             my $i;

--- a/lib/App/perlmv/scriptlet/remove_common_suffix.pm
+++ b/lib/App/perlmv/scriptlet/remove_common_suffix.pm
@@ -14,7 +14,7 @@ our $SCRIPTLET = {
     code => sub {
         package
             App::perlmv::code;
-        use vars qw($COMMON_SUFFIX $TESTING $FILES $EXT);
+        our ($COMMON_SUFFIX, $TESTING, $FILES, $EXT);
 
         if (!defined($COMMON_SUFFIX) && !$TESTING) {
             for (@$FILES) { $_ = reverse };


### PR DESCRIPTION
Use of this pragma is discouraged in favour of "our" under 5.06+.

This dist already uses "our" elsewhere.